### PR TITLE
changed exportPathway arguments

### DIFF
--- a/pvxmlrpc/R/exportPathway.R
+++ b/pvxmlrpc/R/exportPathway.R
@@ -1,8 +1,9 @@
-exportPathway <- function(pathway, type, host="localhost", port=9000) {
+exportPathway <- function(pathway, type, outputDir, host="localhost", port=9000) {
   if (missing(pathway)) stop("You must provide a pathway name.");
   if (missing(type)) stop("You must provide what type of output you want.");
+  if (missing(outputDir)) stop("You must provide an output directory.");
   if (match(type, c("png","svg","pdf"), 0) == 0) stop("This type of export is unavailable");
 
   hostUrl = paste("http://", host, ":", port, "/", sep="")
-  xml.rpc(hostUrl, "PathwayHandler.exportPathway", pathway, type)
+  xml.rpc(hostUrl, "PathVisio.exportPathway", pathway, type, outputDir)
 }

--- a/pvxmlrpc/R/exportPathwayasPdf.R
+++ b/pvxmlrpc/R/exportPathwayasPdf.R
@@ -1,6 +1,3 @@
-exportPathwayasPdf <- function(pathway, host="localhost", port=9000) {
-  if (missing(pathway)) stop("You must provide a pathway name.");
- 
-  hostUrl = paste("http://", host, ":", port, "/", sep="")
-  xml.rpc(hostUrl, "PathwayHandler.exportPathway", pathway, "pdf")
+exportPathwayasPdf <- function(pathway,outputDir, host="localhost", port=9000) {
+  exportPathway(pathway,"pdf",outputDir,host,port)
 }

--- a/pvxmlrpc/R/exportPathwayasPng.R
+++ b/pvxmlrpc/R/exportPathwayasPng.R
@@ -1,6 +1,3 @@
-exportPathwayasPng <- function(pathway, host="localhost", port=9000) {
-  if (missing(pathway)) stop("You must provide a pathway name.");
- 
-  hostUrl = paste("http://", host, ":", port, "/", sep="")
-  xml.rpc(hostUrl, "PathwayHandler.exportPathway", pathway, "png")
+exportPathwayasPng <- function(pathway,outputDir, host="localhost", port=9000) {
+    exportPathway(pathway,"png",outputDir,host,port)
 }

--- a/pvxmlrpc/R/exportPathwayasSvg.R
+++ b/pvxmlrpc/R/exportPathwayasSvg.R
@@ -1,6 +1,3 @@
-exportPathwayasSvg <- function(pathway, host="localhost", port=9000) {
-  if (missing(pathway)) stop("You must provide a pathway name.");
- 
-  hostUrl = paste("http://", host, ":", port, "/", sep="")
-  xml.rpc(hostUrl, "PathwayHandler.exportPathway", pathway, "svg")
+exportPathwayasSvg <- function(pathway,outputDir, host="localhost", port=9000) {
+    exportPathway(pathway,"svg",outputDir,host,port)
 }


### PR DESCRIPTION
1: I think it's unnecessary to have the ability to change the type in the exportPathwayasPng() command. And it didn't match the exportPathway.rd file.

2: exportPathwayas... arguments might just as well use the exportPathway function

3: exportPathway function needs to use PathVisio.exportPathway instead of PathwayHandler.exportPathway. Also an ouput directory is required

ps: if the output directory is a non existing directory the function does not seem to work
